### PR TITLE
Add a missing 'time' import

### DIFF
--- a/usr/lib/python3/dist-packages/mintreport.py
+++ b/usr/lib/python3/dist-packages/mintreport.py
@@ -5,6 +5,8 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 from abc import ABC, abstractmethod
+import time
+
 
 class InfoReport(ABC):
 


### PR DESCRIPTION
time.sleep() is called in InfoReport.remove_packages() [which seems
like an unused method].