### PR TITLE
Use existing translations

### DIFF
--- a/usr/lib/linuxmint/mintreport/app.py
+++ b/usr/lib/linuxmint/mintreport/app.py
@@ -21,10 +21,7 @@ setproctitle.setproctitle("mintreport")
 # i18n
 APP = 'mintreport'
 LOCALE_DIR = "/usr/share/locale"
-locale.bindtextdomain(APP, LOCALE_DIR)
-gettext.bindtextdomain(APP, LOCALE_DIR)
-gettext.textdomain(APP)
-_ = gettext.gettext
+gettext.install(APP, LOCALE_DIR, names="ngettext")
 
 TMP_DIR = "/tmp/mintreport"
 TMP_INFO_DIR = os.path.join(TMP_DIR, "reports")


### PR DESCRIPTION
The button "Ignore this report" is not translated.
The translations do exists already in Mint 20, but the button doesn't
use it.