### PR TITLE
Change symbolic icon for ownership report

### DIFF
--- a/usr/share/linuxmint/mintreport/reports/100_correct-ownership/MintReportInfo.py
+++ b/usr/share/linuxmint/mintreport/reports/100_correct-ownership/MintReportInfo.py
@@ -16,7 +16,7 @@ class Report(InfoReport):
         gettext.install("mintreport", "/usr/share/locale", names="ngettext")
 
         self.title = _("Correct file ownership problem")
-        self.icon = "mintreport-symbolic"
+        self.icon = "dialog-password-symbolic"
         self.has_ignore_button = True
         self.files = ""
 


### PR DESCRIPTION
Since we look for files, which are owned by root, I think the key icon looks better, especially since you are asked for your root password if you click on the button to fix this issue.
Before:
![screenshot-area-2020-12-04-150040](https://user-images.githubusercontent.com/8415124/101172452-8067ea00-3641-11eb-84e1-41b3b72ac033.png)
After:
![screenshot-area-2020-12-04-144549](https://user-images.githubusercontent.com/8415124/101172500-8b227f00-3641-11eb-8f3b-ee68ebb99b0f.png)
