### PR TITLE
fix(main_stack): Missing end margin

### DIFF
--- a/usr/share/linuxmint/mintreport/mintreport.ui
+++ b/usr/share/linuxmint/mintreport/mintreport.ui
@@ -48,6 +48,7 @@
               <object class="GtkStack" id="main_stack">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="margin-end">12</property>
                 <property name="margin-top">12</property>
                 <property name="margin-bottom">12</property>
                 <child>


### PR DESCRIPTION
The main stack was missing  end/right margins, the left margins were already provided by the container gtk box spacing property 