### PR TITLE
Update app.py - increase inxi verbosity

### DIFF
--- a/usr/lib/linuxmint/mintreport/app.py
+++ b/usr/lib/linuxmint/mintreport/app.py
@@ -271,7 +271,7 @@ class MintReportWindow():
     @_async
     def load_sysinfo(self):
         try:
-            sysinfo = subprocess.check_output("LANG=C inxi -Fxxrzc0 --usb", shell=True).decode("utf-8", errors='replace')
+            sysinfo = subprocess.check_output("LANG=C inxi -Fxxxrzc0 --usb", shell=True).decode("utf-8", errors='replace')
             self.add_sysinfo_to_textview(sysinfo)
             with open(TMP_INXI_FILE, "w") as f:
                 f.write(sysinfo)


### PR DESCRIPTION
Add a third 'x' option to the inxi command so it will also provide the partitioning scheme for drives. It is useful for people helping with installation or boot issues to know upfront whether GPT or MBR is used.