### PR TITLE
Fix indentation increasing for each level in USB device tree

### DIFF
--- a/usr/lib/linuxmint/mintreport/usb.py
+++ b/usr/lib/linuxmint/mintreport/usb.py
@@ -134,7 +134,6 @@ class USBListWidget(Gtk.ScrolledWindow):
 
         self.treeview = Gtk.TreeView(model=self.treestore)
         self.treeview.connect("row-activated", self.on_row_activated)
-        self.treeview.set_property("level-indentation", 10)
         self.treeview.set_enable_tree_lines(True)
         self.treeview.set_property("expand", True)
         self.treeview.set_headers_clickable(True)


### PR DESCRIPTION
Fixes #112 

Each indentation level had more spacing between the tree and the icon.

Before : 
<img width="1024" height="687" alt="Capture d’écran du 2026-01-12 19-15-06" src="https://github.com/user-attachments/assets/1f98b1e1-6bc1-47d7-a830-92140c7eec71" />

After : 
<img width="1024" height="687" alt="Capture d’écran du 2026-01-12 19-15-39" src="https://github.com/user-attachments/assets/4b401ba3-d6a7-4bcf-9e4f-73dd81351eb9" />
