### PR TITLE
Fix usb speed display

### DIFF
--- a/usr/lib/linuxmint/mintreport/usb.py
+++ b/usr/lib/linuxmint/mintreport/usb.py
@@ -37,7 +37,7 @@ def speed_label(speed_mbps):
         return speed_mbps
 
     if val >= 10000:
-        return _("%s Gbps") % ("%d" % (val / 1000))
+        return _("%d Gbps") % (val / 1000)
     else:
         return _("%s Mbps") % speed_mbps
 


### PR DESCRIPTION
Fix the display of the USB speed : 

1. Speeds in Gpbs are not converted before being displayed (unit is Gpbs, but the actual value is still in Mbps)
2. Speeds that were not integer caused the function to fail.

To fix it, I replaced all the %d strings by %s, so that we can directly print strings.
When the speed is high enough, we still convert it to Gpbs
When it isnt, directly print the value obtained, it is already in Mbps and requires no conversion.

Closes #111 

(It builds upon my previous MR #113)

I still need to test on another PC with 20 gpbs USB, hence marking as "draft" for one day.