### PR TITLE
Add sensors page

### DIFF
--- a/usr/lib/linuxmint/mintreport/app.py
+++ b/usr/lib/linuxmint/mintreport/app.py
@@ -25,6 +25,8 @@ from bios import BIOSListWidget
 from pci import PCIListWidget
 from usb import USBListWidget
 from gpu import GPUListWidget
+from sensors import SensorsListWidget
+
 
 setproctitle.setproctitle("mintreport")
 _ = xapp.util.l10n("mintreport")
@@ -68,6 +70,7 @@ class MyApplication(Gtk.Application):
         group.add_argument("--bios", action="store_const", dest="page", const="bios")
         group.add_argument("--pci", action="store_const", dest="page", const="pci")
         group.add_argument("--gpu", action="store_const", dest="page", const="gpu")
+        group.add_argument("--sensors", action="store_const", dest="page", const="sensors")
         argv = command_line.get_arguments()[1:]
         args, _ = parser.parse_known_args(argv)
         if args.page is None:
@@ -405,7 +408,6 @@ class MintReportWindow():
         self.builder.get_object("button_sysinfo_copy").connect("clicked", self.copy_inxi_info)
         self.builder.get_object("button_sysinfo_upload").connect("clicked", self.upload_inxi_info)
 
-
         # USB page
         self.usb_widget = USBListWidget()
         self.builder.get_object("box_usb_widget").pack_start(self.usb_widget, True, True, 0)
@@ -413,6 +415,10 @@ class MintReportWindow():
         # PCI page
         self.pci_widget = PCIListWidget()
         self.builder.get_object("box_pci_widget").pack_start(self.pci_widget, True, True, 0)
+
+        # Sensors page
+        self.sensors_widget = SensorsListWidget()
+        self.builder.get_object("box_sensors_widget").pack_start(self.sensors_widget, True, True, 0)
 
         # BIOS page
         self.bios_widget = BIOSListWidget()
@@ -427,6 +433,7 @@ class MintReportWindow():
         self.load_pci()
         self.load_bios()
         self.load_gpu()
+        self.load_sensors()
 
     def show_page(self, page_name):
         page_name = f"page_{page_name}"
@@ -584,6 +591,10 @@ class MintReportWindow():
     @xt.run_async
     def load_pci(self):
         self.pci_widget.load()
+
+    @xt.run_async
+    def load_sensors(self):
+        self.sensors_widget.load()
 
     @xt.run_async
     def load_bios(self):

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -15,28 +15,28 @@ def format_sensor(filename, raw):
     raw = raw.strip()
 
     if filename.startswith("temp"):
-        return f"{int(raw)/1000:.1f}", _("°C"), "xsi-temperature-symbolic"
+        return f"{int(raw)/1000:.1f}", "°C", "xsi-temperature-symbolic"
 
     if filename.startswith("fan"):
         return raw, _("RPM"), "xsi-cog-symbolic"
 
     if filename.startswith("pwm"):
-        return f"{int(raw)*100/255:.0f}", _("%"), "xsi-cog-symbolic"
+        return f"{int(raw)*100/255:.0f}", "%", "xsi-cog-symbolic"
 
     if filename.startswith("in"):
-        return f"{int(raw)/1000:.3f}", _("V"), "xsi-cog-symbolic"
+        return f"{int(raw)/1000:.3f}", "V", "xsi-cog-symbolic"
 
     if filename.startswith("curr"):
-        return f"{int(raw)/1000:.3f}", _("A"), "xsi-cog-symbolic"
+        return f"{int(raw)/1000:.3f}", "A", "xsi-cog-symbolic"
 
     if filename.startswith("power"):
-        return f"{int(raw)/1_000_000:.1f}", _("W"), "xsi-cog-symbolic"
+        return f"{int(raw)/1_000_000:.1f}", "W", "xsi-cog-symbolic"
 
     if filename.startswith("freq"):
-        return f"{int(raw)/1_000_000_000:.3f}", _("GHz"), "xsi-cog-symbolic"
+        return f"{int(raw)/1_000_000_000:.3f}", "GHz", "xsi-cog-symbolic"
 
     if filename.startswith("energy"):
-        return f"{int(raw)/1_000_000:.3f}", _("J"), "xsi-cog-symbolic"
+        return f"{int(raw)/1_000_000:.3f}", "J", "xsi-cog-symbolic"
 
     return raw, "", "xsi-cpu-symbolic"
 

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -30,10 +30,13 @@ def format_sensor(filename, raw):
         return f"{int(raw)/1000:.3f}", _("A"), "xsi-cpu-symbolic"
 
     if filename.startswith("power"):
-        return f"{int(raw)/1_000_000:.2f}", _("W"), "xsi-cpu-symbolic"
+        return f"{int(raw)/1_000_000:.1f}", _("W"), "xsi-cpu-symbolic"
+
+    if filename.startswith("freq"):
+        return f"{int(raw)/1_000_000_000:.3f}", _("GHz"), "xsi-cpu-symbolic"
 
     if filename.startswith("energy"):
-        return f"{int(raw)/1_000_000:.2f}", _("J"), "xsi-cpu-symbolic"
+        return f"{int(raw)/1_000_000:.3f}", _("J"), "xsi-cpu-symbolic"
 
     return raw, "", "xsi-cpu-symbolic"
 

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -189,7 +189,8 @@ class SensorsListWidget(Gtk.ScrolledWindow):
         if not os.path.isdir(SYS_HWMON):
             return
 
-        for hwmon in os.listdir(SYS_HWMON):
+        # sort hwmon folders by natural order, as the listdir order is random
+        for hwmon in sorted(os.listdir(SYS_HWMON), key=natural_key):
             hwmon_path = os.path.join(SYS_HWMON, hwmon)
             device_path = os.path.join(hwmon_path, "device")
 

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -1,0 +1,176 @@
+import os
+import gi
+import xapp.util
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib, Pango
+
+_ = xapp.util.l10n("mintreport")
+
+SYS_HWMON = "/sys/class/hwmon"
+
+(
+    COL_NAME,
+    COL_VALUE,
+    COL_UNIT,
+    COL_SENSITIVE,
+    COL_ICON,
+) = range(5)
+
+
+class SensorsListWidget(Gtk.ScrolledWindow):
+    ICONS = {
+        "root": "xsi-cpu-symbolic",
+        "temp": "xsi-temperature-symbolic",
+        "fan": "xsi-cpu-symbolic",
+        "in": "xsi-cpu-symbolic",
+        "power": "xsi-cpu-symbolic",
+        "other": "xsi-cpu-symbolic",
+    }
+
+    def __init__(self):
+        super().__init__()
+
+        # TreeStore with icon, name, value, unit
+        self.treestore = Gtk.TreeStore(str, str, str, bool, str)
+        self.treeview = Gtk.TreeView(model=self.treestore)
+        self.treeview.set_enable_tree_lines(True)
+        self.treeview.set_headers_clickable(True)
+
+        # First column: tree + icon + name
+        renderer = Gtk.CellRendererPixbuf()
+        column = Gtk.TreeViewColumn("", renderer, icon_name=COL_ICON)
+        column.set_expand(False)
+        self.treeview.append_column(column)
+
+        renderer = Gtk.CellRendererText()
+        renderer.set_property("ellipsize", Pango.EllipsizeMode.END)
+        column = Gtk.TreeViewColumn(_("Sensor"), renderer, text=COL_NAME)
+        column.set_expand(True)
+        self.treeview.append_column(column)
+
+        # Value column
+        renderer = Gtk.CellRendererText()
+        column = Gtk.TreeViewColumn(_("Value"), renderer, text=COL_VALUE)
+        column.set_expand(False)
+        self.treeview.append_column(column)
+
+        # Unit column
+        renderer = Gtk.CellRendererText()
+        column = Gtk.TreeViewColumn(_("Unit"), renderer, text=COL_UNIT)
+        column.set_expand(False)
+        self.treeview.append_column(column)
+
+        self.add(self.treeview)
+        self.set_shadow_type(Gtk.ShadowType.IN)
+
+        self.hwmon_parents = {}
+        self.sensor_rows = {}
+
+    # ------------------------------------------------------------------
+    def load(self):
+        self.build_tree()
+        self.refresh_values()
+        GLib.timeout_add_seconds(1, self.refresh_values)
+
+    # ------------------------------------------------------------------
+    def build_tree(self):
+        self.treestore.clear()
+        self.hwmon_parents.clear()
+        self.sensor_rows.clear()
+
+        if not os.path.isdir(SYS_HWMON):
+            return
+
+        for hwmon in sorted(os.listdir(SYS_HWMON)):
+            hwmon_path = os.path.join(SYS_HWMON, hwmon)
+            device_path = os.path.join(hwmon_path, "device")
+
+            # Determine base path for sensors
+            base_path = None
+            if os.path.isdir(device_path):
+                # Use device/ only if it contains *_input files
+                inputs = [f for f in os.listdir(device_path) if f.endswith("_input")]
+                if inputs:
+                    base_path = device_path
+            if base_path is None:
+                base_path = hwmon_path
+
+            # Root name
+            name_file = os.path.join(base_path, "name")
+            name = self._read_file(name_file)
+            name = name.strip() if name else hwmon
+
+            parent = self.treestore.append(
+                None, [name, "", "", False, self.ICONS["root"]]
+            )
+            self.hwmon_parents[hwmon_path] = parent
+
+            # Process all *_input files in base_path
+            for fname in sorted(os.listdir(base_path)):
+                if not fname.endswith("_input"):
+                    continue
+
+                fpath = os.path.join(base_path, fname)
+                raw = self._read_file(fpath)
+                if raw is None:
+                    continue
+
+                # Label
+                label_file = fpath.replace("_input", "_label")
+                label = self._read_file(label_file)
+                label = label.strip() if label else fname.replace("_input", "")
+
+                unit, display, stype = self.format_sensor(fname, raw)
+
+                itr = self.treestore.append(
+                    parent,
+                    [label, display, unit, True, self.ICONS.get(stype, self.ICONS["other"])],
+                )
+                self.sensor_rows[fpath] = itr
+
+        self.treeview.expand_all()
+
+    # ------------------------------------------------------------------
+    def refresh_values(self):
+        for fpath, itr in self.sensor_rows.items():
+            raw = self._read_file(fpath)
+            if raw is None:
+                continue
+
+            fname = os.path.basename(fpath)
+            _, display, _ = self.format_sensor(fname, raw)
+            self.treestore.set_value(itr, COL_VALUE, display)
+
+        return True
+
+    # ------------------------------------------------------------------
+    def format_sensor(self, filename, raw):
+        raw = raw.strip()
+        stype = "other"
+
+        if filename.startswith("temp"):
+            stype = "temp"
+            return "°C", f"{int(raw)/1000:.1f}", stype
+
+        if filename.startswith("fan"):
+            stype = "fan"
+            return "RPM", raw, stype
+
+        if filename.startswith("in"):
+            stype = "in"
+            return "V", f"{int(raw)/1000:.3f}", stype
+
+        if filename.startswith("power"):
+            stype = "power"
+            return "W", f"{int(raw)/1_000_000:.2f}", stype
+
+        return "", raw, stype
+
+    # ------------------------------------------------------------------
+    def _read_file(self, path):
+        try:
+            with open(path, "r") as f:
+                return f.read()
+        except Exception:
+            return None

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -18,25 +18,25 @@ def format_sensor(filename, raw):
         return f"{int(raw)/1000:.1f}", _("°C"), "xsi-temperature-symbolic"
 
     if filename.startswith("fan"):
-        return raw, _("RPM"), "xsi-cpu-symbolic"
+        return raw, _("RPM"), "xsi-cog-symbolic"
 
     if filename.startswith("pwm"):
-        return f"{int(raw)*100/255:.0f}", _("%"), "xsi-cpu-symbolic"
+        return f"{int(raw)*100/255:.0f}", _("%"), "xsi-cog-symbolic"
 
     if filename.startswith("in"):
-        return f"{int(raw)/1000:.3f}", _("V"), "xsi-cpu-symbolic"
+        return f"{int(raw)/1000:.3f}", _("V"), "xsi-cog-symbolic"
 
     if filename.startswith("curr"):
-        return f"{int(raw)/1000:.3f}", _("A"), "xsi-cpu-symbolic"
+        return f"{int(raw)/1000:.3f}", _("A"), "xsi-cog-symbolic"
 
     if filename.startswith("power"):
-        return f"{int(raw)/1_000_000:.1f}", _("W"), "xsi-cpu-symbolic"
+        return f"{int(raw)/1_000_000:.1f}", _("W"), "xsi-cog-symbolic"
 
     if filename.startswith("freq"):
-        return f"{int(raw)/1_000_000_000:.3f}", _("GHz"), "xsi-cpu-symbolic"
+        return f"{int(raw)/1_000_000_000:.3f}", _("GHz"), "xsi-cog-symbolic"
 
     if filename.startswith("energy"):
-        return f"{int(raw)/1_000_000:.3f}", _("J"), "xsi-cpu-symbolic"
+        return f"{int(raw)/1_000_000:.3f}", _("J"), "xsi-cog-symbolic"
 
     return raw, "", "xsi-cpu-symbolic"
 
@@ -108,6 +108,7 @@ class SensorsListWidget(Gtk.ScrolledWindow):
             base_path = None
             if os.path.isdir(device_path):
                 # Use device/ only if it contains *_input files
+                # This is required as some modules put sensors files in the device folder (apple-smc for example)
                 inputs = [f for f in os.listdir(device_path) if f.endswith("_input")]
                 if inputs:
                     base_path = device_path

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -151,12 +151,13 @@ class SensorsListWidget(Gtk.ScrolledWindow):
 
                 device_without_sensors = False;
 
-            if (device_without_sensors):
+            if device_without_sensors:
                 self.treestore.set_value(parent, COL_SENSITIVE, False)
 
         self.treeview.expand_all()
 
     def refresh_values(self):
+        self.treestore.freeze_notify()
         for fpath, itr in self.sensor_rows.items():
             raw = self._read_file(fpath)
             if raw is None:
@@ -164,8 +165,9 @@ class SensorsListWidget(Gtk.ScrolledWindow):
 
             fname = os.path.basename(fpath)
             value, _, _ = format_sensor(fname, raw)
-            self.treestore.set_value(itr, COL_VALUE, value)
-
+            if value != self.treestore.get_value(itr, COL_VALUE):
+                self.treestore.set_value(itr, COL_VALUE, value)
+        self.treestore.thaw_notify()
         return True
 
     def _read_file(self, path):

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -1,17 +1,16 @@
 import os
 import gi
 import xapp.util
+import xapp.SettingsWidgets as Xs
 import re
 from enum import IntEnum
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib, Pango
+from gi.repository import Gtk, GLib
 
 _ = xapp.util.l10n("mintreport")
 
 SYS_HWMON = "/sys/class/hwmon"
-
-COL_NAME, COL_VALUE, COL_UNIT, COL_SENSITIVE, COL_ICON_NAME = range(5)
 
 class SensorType(IntEnum):
     TEMP = 0
@@ -41,7 +40,7 @@ SENSOR_SPECS = {
     },
     SensorType.PWM: {
         "prefix":"pwm",
-        "suffix":"", # no _input suffix for pwm
+        "suffix":"", # no _input suffix for pwm
         "format":lambda raw: f"{int(raw)*100/255:.0f}",
         "unit":"%",
         "icon":"xsi-fan-symbolic"
@@ -113,49 +112,17 @@ class SensorsListWidget(Gtk.ScrolledWindow):
 
     def __init__(self):
         super().__init__()
+        self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
-        self.treestore = Gtk.TreeStore(str, str, str, bool, str)
+        self.page = Xs.SettingsPage()
+        self.page.set_spacing(24)
+        self.page.set_margin_left(24)
+        self.page.set_margin_right(24)
+        self.page.set_margin_top(12)
+        self.page.set_margin_bottom(12)
+        self.add(self.page)
 
-        self.treeview = Gtk.TreeView(model=self.treestore)
-        self.treeview.set_enable_tree_lines(True)
-        self.treeview.set_property("expand", True)
-        self.treeview.set_headers_clickable(True)
-
-        # --- Columns ---
-        # Name column with device icon
-        icon_renderer = Gtk.CellRendererPixbuf()
-        icon_renderer.set_property("xpad", 2)
-        icon_renderer.set_property("ypad", 2)
-        text_renderer = Gtk.CellRendererText()
-        text_renderer.set_property("ypad", 6)
-        column = Gtk.TreeViewColumn(_("Name"))
-        column.pack_start(icon_renderer, False)
-        column.pack_start(text_renderer, True)
-        column.add_attribute(icon_renderer, "icon-name", COL_ICON_NAME)
-        column.add_attribute(text_renderer, "text", COL_NAME)
-        column.add_attribute(text_renderer, "sensitive", COL_SENSITIVE)
-        text_renderer.set_property("ellipsize", Pango.EllipsizeMode.END)
-        column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
-        self.treeview.append_column(column)
-        column.set_expand(True)
-        column.set_resizable(True)
-
-        # Value column
-        renderer = Gtk.CellRendererText()
-        column = Gtk.TreeViewColumn(_("Value"), renderer, text=COL_VALUE)
-        column.set_expand(False)
-        self.treeview.append_column(column)
-
-        # Unit column
-        renderer = Gtk.CellRendererText()
-        column = Gtk.TreeViewColumn(_("Unit"), renderer, text=COL_UNIT)
-        column.set_expand(False)
-        self.treeview.append_column(column)
-
-        self.add(self.treeview)
-        self.set_shadow_type(Gtk.ShadowType.IN)
-
-        self.sensor_rows = {}
+        self.sensor_rows = {}  # fpath -> (value_label, stype)
 
         self.timeout_id = None
         self.refresh_interval = 1 # seconds
@@ -167,25 +134,26 @@ class SensorsListWidget(Gtk.ScrolledWindow):
         # do nothing, we do everything in the _on_map() function
         pass
 
-    def _on_map(self, *arg):
+    def _on_map(self, *_):
         if self.timeout_id is None:
-            # Refresh existing tree or build it is does not exist yet
+            # Refresh existing cards or build them if they don't exist yet
             if self.sensor_rows:
                 self.refresh_values()
             else:
-                self.build_tree()
+                self.build_cards()
 
             self.timeout_id = GLib.timeout_add_seconds(
                 self.refresh_interval, self.refresh_values
             )
 
-    def _on_unmap(self, *arg):
+    def _on_unmap(self, *_):
         if self.timeout_id is not None:
             GLib.source_remove(self.timeout_id)
             self.timeout_id = None
 
-    def build_tree(self):
-        self.treestore.clear()
+    def build_cards(self):
+        for child in self.page.get_children():
+            self.page.remove(child)
         self.sensor_rows.clear()
 
         if not os.path.isdir(SYS_HWMON):
@@ -212,13 +180,7 @@ class SensorsListWidget(Gtk.ScrolledWindow):
             name = self._read_file(name_file)
             name = name.strip() if name else hwmon
 
-            parent = self.treestore.append(
-                None, [name, "", "", True, "xsi-cpu-symbolic"]
-            )
-
-            device_without_sensors = True
-
-            # Process all *_input files in base_path
+            # Process all sensor files in base_path
             sensors = []
             for fname in os.listdir(base_path):
                 stype, spec = sensor_spec_from_filename(fname)
@@ -245,28 +207,39 @@ class SensorsListWidget(Gtk.ScrolledWindow):
                     "type": stype,
                 })
 
+            if not sensors:
+                continue
+
             sort_sensors(sensors)
 
-            # Add sorted sensors to treestore
+            section = self.page.add_section(name)
+
             for s in sensors:
-                itr = self.treestore.append(
-                    parent,
-                    [s["label"], s["value"], s["unit"],  True, s["icon"]],
-                )
+                row = Xs.SettingsWidget()
+                row.set_spacing(8)
 
-                # Store TreeStore itr and sensor type by path for refresh
-                self.sensor_rows[s["path"]] = (itr, s["type"])
-                device_without_sensors = False
+                icon = Gtk.Image.new_from_icon_name(s["icon"], Gtk.IconSize.MENU)
+                icon.set_pixel_size(16)
+                row.pack_start(icon, False, False, 0)
 
-            if device_without_sensors:
-                self.treestore.set_value(parent, COL_SENSITIVE, False)
+                name_label = Gtk.Label(label=s["label"])
+                name_label.set_xalign(0)
+                row.pack_start(name_label, True, True, 0)
 
-        self.treeview.expand_all()
+                value_label = Gtk.Label(label=s["value"])
+                value_label.get_style_context().add_class("dim-label")
+                unit_label = Gtk.Label(label=s["unit"])
+                unit_label.get_style_context().add_class("dim-label")
+                row.pack_end(unit_label, False, False, 0)
+                row.pack_end(value_label, False, False, 0)
+
+                section.add_row(row)
+                self.sensor_rows[s["path"]] = (value_label, s["type"])
+
+        self.page.show_all()
 
     def refresh_values(self):
-        self.treestore.freeze_notify()
-
-        for fpath, (itr, stype) in self.sensor_rows.items():
+        for fpath, (value_label, stype) in self.sensor_rows.items():
             raw = self._read_file(fpath)
             if raw is None:
                 continue
@@ -274,10 +247,9 @@ class SensorsListWidget(Gtk.ScrolledWindow):
             spec = SENSOR_SPECS[stype]
             value = spec["format"](raw)
 
-            if value != self.treestore.get_value(itr, COL_VALUE):
-                self.treestore.set_value(itr, COL_VALUE, value)
+            if value != value_label.get_text():
+                value_label.set_text(value)
 
-        self.treestore.thaw_notify()
         return True
 
     def _read_file(self, path):

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -48,21 +48,21 @@ SENSOR_SPECS = {
     SensorType.FREQ: {
         "prefix":"freq",
         "suffix":"_input",
-        "format":lambda raw: f"{int(raw)/1_000_000_000:.3f}",
+        "format":lambda raw: f"{int(raw)/1_000_000_000:.2f}",
         "unit":"GHz",
         "icon":"xsi-physics-wavelength-symbolic"
     },
     SensorType.VOLTAGE: {
         "prefix":"in",
         "suffix":"_input",
-        "format":lambda raw: f"{int(raw)/1000:.3f}",
+        "format":lambda raw: f"{int(raw)/1000:.2f}",
         "unit":"V",
         "icon":"xsi-physics-volts-symbolic"
     },
     SensorType.CURRENT: {
         "prefix":"curr",
         "suffix":"_input",
-        "format":lambda raw: f"{int(raw)/1000:.3f}",
+        "format":lambda raw: f"{int(raw)/1000:.2f}",
         "unit":"A",
         "icon":"xsi-physics-wave-symbolic"
     },
@@ -76,7 +76,7 @@ SENSOR_SPECS = {
     SensorType.ENERGY: {
         "prefix":"energy",
         "suffix":"_input",
-        "format":lambda raw: f"{int(raw)/1_000_000:.3f}",
+        "format":lambda raw: f"{int(raw)/1_000_000:.1f}",
         "unit":"J",
         "icon":"xsi-power-symbolic"
     }
@@ -123,6 +123,8 @@ class SensorsListWidget(Gtk.ScrolledWindow):
         self.add(self.page)
 
         self.sensor_rows = {}  # fpath -> (value_label, stype)
+        self.value_size_group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
+        self.unit_size_group = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
 
         self.timeout_id = None
         self.refresh_interval = 1 # seconds
@@ -228,8 +230,12 @@ class SensorsListWidget(Gtk.ScrolledWindow):
 
                 value_label = Gtk.Label(label=s["value"])
                 value_label.get_style_context().add_class("dim-label")
+                value_label.set_xalign(1.0)
                 unit_label = Gtk.Label(label=s["unit"])
                 unit_label.get_style_context().add_class("dim-label")
+                unit_label.set_xalign(0.0)
+                self.value_size_group.add_widget(value_label)
+                self.unit_size_group.add_widget(unit_label)
                 row.pack_end(unit_label, False, False, 0)
                 row.pack_end(value_label, False, False, 0)
 

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -37,49 +37,49 @@ SENSOR_SPECS = {
         "suffix":"_input",
         "format":lambda raw: raw.strip(),
         "unit":_("RPM"),
-        "icon":"xsi-cog-symbolic"
+        "icon":"xsi-fan-symbolic"
     },
     SensorType.PWM: {
         "prefix":"pwm",
         "suffix":"", # no _input suffix for pwm
         "format":lambda raw: f"{int(raw)*100/255:.0f}",
         "unit":"%",
-        "icon":"xsi-cog-symbolic"
+        "icon":"xsi-fan-symbolic"
     },
     SensorType.FREQ: {
         "prefix":"freq",
         "suffix":"_input",
         "format":lambda raw: f"{int(raw)/1_000_000_000:.3f}",
         "unit":"GHz",
-        "icon":"xsi-cog-symbolic"
+        "icon":"xsi-physics-wavelength-symbolic"
     },
     SensorType.VOLTAGE: {
         "prefix":"in",
         "suffix":"_input",
         "format":lambda raw: f"{int(raw)/1000:.3f}",
         "unit":"V",
-        "icon":"xsi-cog-symbolic"
+        "icon":"xsi-physics-volts-symbolic"
     },
     SensorType.CURRENT: {
         "prefix":"curr",
         "suffix":"_input",
         "format":lambda raw: f"{int(raw)/1000:.3f}",
         "unit":"A",
-        "icon":"xsi-cog-symbolic"
+        "icon":"xsi-physics-wave-symbolic"
     },
     SensorType.POWER: {
         "prefix":"power",
         "suffix":"_input",
         "format":lambda raw: f"{int(raw)/1_000_000:.1f}",
         "unit":"W",
-        "icon":"xsi-cog-symbolic"
+        "icon":"xsi-physics-watts-symbolic"
     },
     SensorType.ENERGY: {
         "prefix":"energy",
         "suffix":"_input",
         "format":lambda raw: f"{int(raw)/1_000_000:.3f}",
         "unit":"J",
-        "icon":"xsi-cog-symbolic"
+        "icon":"xsi-power-symbolic"
     }
 }
 

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -25,57 +25,49 @@ class SensorType(IntEnum):
 
 SENSOR_SPECS = {
     SensorType.TEMP: {
-        "prefix":"temp",
-        "suffix":"_input",
+        "pattern":re.compile(r"^(temp\d+)_input$"),
         "format":lambda raw: f"{int(raw)/1000:.1f}",
         "unit":"°C",
         "icon":"xsi-temperature-symbolic"
     },
     SensorType.FAN: {
-        "prefix":"fan",
-        "suffix":"_input",
+        "pattern":re.compile(r"^(fan\d+)_input$"),
         "format":lambda raw: raw.strip(),
         "unit":_("RPM"),
         "icon":"xsi-fan-symbolic"
     },
     SensorType.PWM: {
-        "prefix":"pwm",
-        "suffix":"", # no _input suffix for pwm
+        "pattern":re.compile(r"^(pwm\d+)$"), # no _input suffix for pwm type
         "format":lambda raw: f"{int(raw)*100/255:.0f}",
         "unit":"%",
         "icon":"xsi-fan-symbolic"
     },
     SensorType.FREQ: {
-        "prefix":"freq",
-        "suffix":"_input",
+        "pattern":re.compile(r"^(freq\d+)_input$"),
         "format":lambda raw: f"{int(raw)/1_000_000_000:.2f}",
         "unit":"GHz",
         "icon":"xsi-physics-wavelength-symbolic"
     },
     SensorType.VOLTAGE: {
-        "prefix":"in",
-        "suffix":"_input",
+        "pattern":re.compile(r"^(in\d+)_input$"),
         "format":lambda raw: f"{int(raw)/1000:.2f}",
         "unit":"V",
         "icon":"xsi-physics-volts-symbolic"
     },
     SensorType.CURRENT: {
-        "prefix":"curr",
-        "suffix":"_input",
+        "pattern":re.compile(r"^(curr\d+)_input$"),
         "format":lambda raw: f"{int(raw)/1000:.2f}",
         "unit":"A",
         "icon":"xsi-physics-wave-symbolic"
     },
     SensorType.POWER: {
-        "prefix":"power",
-        "suffix":"_input",
+        "pattern":re.compile(r"^(power\d+)_input$"),
         "format":lambda raw: f"{int(raw)/1_000_000:.1f}",
         "unit":"W",
         "icon":"xsi-physics-watts-symbolic"
     },
     SensorType.ENERGY: {
-        "prefix":"energy",
-        "suffix":"_input",
+        "pattern":re.compile(r"^(energy\d+)_input$"),
         "format":lambda raw: f"{int(raw)/1_000_000:.1f}",
         "unit":"J",
         "icon":"xsi-power-symbolic"
@@ -84,11 +76,11 @@ SENSOR_SPECS = {
 
 def sensor_spec_from_filename(filename):
     for stype, spec in SENSOR_SPECS.items():
-        prefix = spec["prefix"]
-        suffix = spec["suffix"]
-        if filename.startswith(prefix) and filename.endswith(suffix):
-            return stype, spec
-    return None, None
+        m = spec["pattern"].match(filename)
+        if m:
+            base = m.group(1)
+            return stype, spec, base
+    return None, None, None
 
 # Helper funcs to sort sensors in correct numerical order (ex in10 after in9)
 def natural_key(label):
@@ -186,7 +178,7 @@ class SensorsListWidget(Gtk.ScrolledWindow):
             # Process all sensor files in base_path
             sensors = []
             for fname in os.listdir(base_path):
-                stype, spec = sensor_spec_from_filename(fname)
+                stype, spec, base_name = sensor_spec_from_filename(fname)
                 if spec is None:
                     continue    # that's not a sensor
 
@@ -196,8 +188,7 @@ class SensorsListWidget(Gtk.ScrolledWindow):
                     continue    # unable to read sensor -> skip
 
                 # Label
-                labelname = fname.replace(spec["suffix"], "_label")
-                labelpath = os.path.join(base_path, labelname)
+                labelpath = os.path.join(base_path, f"{base_name}_label")
                 label = self._read_file(labelpath)
                 label = label.strip() if label else fname.replace("_input", "")
 

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -161,7 +161,8 @@ class SensorsListWidget(Gtk.ScrolledWindow):
         if not os.path.isdir(SYS_HWMON):
             return
 
-        # sort hwmon folders by natural order, as the listdir order is random
+        # First pass: collect all chips with their sensors
+        chips = []
         for hwmon in sorted(os.listdir(SYS_HWMON), key=natural_key):
             hwmon_path = os.path.join(SYS_HWMON, hwmon)
             device_path = os.path.join(hwmon_path, "device")
@@ -213,6 +214,17 @@ class SensorsListWidget(Gtk.ScrolledWindow):
                 continue
 
             sort_sensors(sensors)
+            chips.append((hwmon, name, sensors))
+
+        # Disambiguate chips that share the same name (e.g. two RAM sticks: spd5118)
+        name_counts = {}
+        for _, name, _ in chips:
+            name_counts[name] = name_counts.get(name, 0) + 1
+
+        # Second pass: build cards
+        for hwmon, name, sensors in chips:
+            if name_counts[name] > 1:
+                name = f"{name} ({hwmon})"
 
             section = self.page.add_section(name)
 

--- a/usr/lib/linuxmint/mintreport/sensors.py
+++ b/usr/lib/linuxmint/mintreport/sensors.py
@@ -58,7 +58,7 @@ SENSOR_SPECS = {
         "pattern":re.compile(r"^(curr\d+)_input$"),
         "format":lambda raw: f"{int(raw)/1000:.2f}",
         "unit":"A",
-        "icon":"xsi-physics-wave-symbolic"
+        "icon":"xsi-physics-amps-symbolic"
     },
     SensorType.POWER: {
         "pattern":re.compile(r"^(power\d+)_input$"),

--- a/usr/share/linuxmint/mintreport/mintreport.ui
+++ b/usr/share/linuxmint/mintreport/mintreport.ui
@@ -307,6 +307,34 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkBox" id="box_sensors">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkBox" id="box_sensors_widget">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">pense_sensors</property>
+                    <property name="title" translatable="yes">Sensors</property>
+                    <property name="icon-name">xsi-temperature-symbolic</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkBox" id="box_bios">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -357,7 +385,7 @@
                     <property name="name">page_bios</property>
                     <property name="title" translatable="yes">BIOS</property>
                     <property name="icon-name">xsi-cpu-symbolic</property>
-                    <property name="position">4</property>
+                    <property name="position">5</property>
                   </packing>
                 </child>
                 <child>
@@ -590,7 +618,7 @@
                     <property name="name">page_reports</property>
                     <property name="title" translatable="yes">System Reports</property>
                     <property name="icon-name">mintreport-symbolic</property>
-                    <property name="position">5</property>
+                    <property name="position">6</property>
                   </packing>
                 </child>
                 <child>
@@ -869,7 +897,7 @@
                     <property name="name">page_crashes</property>
                     <property name="title" translatable="yes">Crash Reports</property>
                     <property name="icon-name">xsi-computer-fail-symbolic</property>
-                    <property name="position">6</property>
+                    <property name="position">7</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
Hello,

This PR is not meant to be merged at this point. It is purely a draft, to open the discussion.

I have been really enjoying the latest additions to Mintreport, most notably the USB and PCI pages, that make accessible those information to users unfamiliar with the command line.

Following that, I have been playing with the idea of adding a new tab showing the different hardware sensors (gathered through hwmon).

<img width="1024" height="687" alt="image" src="https://github.com/user-attachments/assets/54441184-c1d0-4860-a4ba-3c019db42db8" />

It has been written in an evening, using AI tooling, and is very crude and missing important bits, notably translatable strings, and a lot of polish.  Some sensors types ("current" for example) and icons are missing, but I think it does a good job of show casing what could be.

Also it is based on my 2 previous PR (#113 and #114)

If this is a path work pursuing, I can invest the work to clean it up until it is mergeable.

What do you think ?