### PR TITLE
BIOS: add "Virtualization" to report

### DIFF
--- a/usr/lib/linuxmint/mintreport/bios.py
+++ b/usr/lib/linuxmint/mintreport/bios.py
@@ -7,7 +7,7 @@ import xapp.threading as xt
 import xapp.util
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-from common import read_dmi, read_efi, clean_brand
+from common import read_dmi, read_efi, clean_brand, read_virt
 
 _ = xapp.util.l10n("mintreport")
 
@@ -54,6 +54,13 @@ class BIOSListWidget(Xs.SettingsPage):
                     infos_bios.append([_('Secure Boot mode'), _("User Mode (normal)")])
             else:
                 infos_bios.append([_('Secure Boot'), _("Disabled")])
+
+        # Virtualization
+        virt = read_virt()
+        virt_value = _('Disabled')
+        if virt:
+            virt_value = _('Enabled (%s)') % virt
+        infos_bios.append([_('Virtualization'), virt_value])
 
         infos_motherboard = []
         infos_motherboard.append([_('Brand'), clean_brand(read_dmi('board_vendor'))])

--- a/usr/lib/linuxmint/mintreport/common.py
+++ b/usr/lib/linuxmint/mintreport/common.py
@@ -129,3 +129,16 @@ BRAND_MAP = {
     "Western Digital": "WD",
     "Xilinx Corporation": "Xilinx",
 }
+
+def read_virt():
+    """Reads '/proc/cpuinfo' to determine whether virtualization is supported."""
+    with open("/proc/cpuinfo", "r") as cpuinfo:
+        for line in cpuinfo:
+            if line[:5] == "flags":
+                if " vmx " in line:
+                    return "VT-x"
+                elif " svm " in line:
+                    return "AMD-V"
+                else:
+                    return None
+


### PR DESCRIPTION
This PR adds a "Virtualization" value to the BIOS report. Its values are either "Disabled" or "Enabled". If enabled, it reports the flavor detected. This uses `/proc/cpuinfo` and is based on the same logic of `lscpu`.

Disabled:
<img width="1024" height="687" alt="Virt Disabled" src="https://github.com/user-attachments/assets/63e42aae-0668-40ad-8ca6-41a94f13228e" />

Enabled:
<img width="1024" height="687" alt="Virt Enabled" src="https://github.com/user-attachments/assets/9fde13fe-2762-49e0-8a1e-47d26b83bfef" />