### PR TITLE
Fix WM_CLASS for correct icon matching in docks and taskbars

### DIFF
--- a/usr/lib/linuxmint/mintreport/app.py
+++ b/usr/lib/linuxmint/mintreport/app.py
@@ -29,6 +29,7 @@ from sensors import SensorsListWidget
 
 
 setproctitle.setproctitle("mintreport")
+GLib.set_prgname("mintreport")
 _ = xapp.util.l10n("mintreport")
 
 TMP_DIR = "/tmp/mintreport"

--- a/usr/share/applications/mintreport.desktop
+++ b/usr/share/applications/mintreport.desktop
@@ -121,3 +121,4 @@ Categories=Application;System;Settings;
 StartupNotify=false
 NotShowIn=KDE;
 Keywords=system;information;details;graphic;kernel;version;about;gpu;bios;pci;usb;
+StartupWMClass=Mintreport


### PR DESCRIPTION
When mintreport is launched, its WM_CLASS is reported as "app.py"/"App.py" 
because the entry point script is named app.py. This causes dock and taskbar 
applications (such as xfce4-docklike-plugin) to fail to match the window to 
its .desktop entry, resulting in a missing or incorrect icon.

Changes:
- Added GLib.set_prgname("mintreport") in app.py to correctly identify 
  the application at the GTK level
- Added StartupWMClass=Mintreport to mintreport.desktop as a fallback 
  for dock/taskbar matching

Tested on Linux Mint 22.3 XFCE with xfce4-docklike-plugin.